### PR TITLE
Update Curl.php

### DIFF
--- a/src/Curl.php
+++ b/src/Curl.php
@@ -34,7 +34,10 @@ class Curl
 		$this->defaultOptions[CURLOPT_SSL_VERIFYPEER] = !$isDebug;
 		$this->defaultOptions[CURLOPT_SSL_VERIFYHOST] = $isDebug ? 0 : 2;
 
-		$this->setOptions(array_merge($this->defaultOptions, $options));
+        //$this->setOptions(array_merge($this->defaultOptions, $options));
+        $this->setOptions($this->defaultOptions); //
+        $this->setOptions($options);
+
 
 		$this->handle = curl_init();
 		$this->id     = (int) $this->handle;


### PR DESCRIPTION
Возможно, баг: в конктрукторе в array_merge попадают не строковые, а цифровые ключи вида 19913, 64, 10036 и т.д. (так как к примеру константа CURLOPT_RETURNTRANSFER на самом деле равно числу 19913, CURLOPT_SSL_VERIFYPEER равна 64 и т.д) - и это при прохождении через array_merge преобразуется в идущие по порядку цифровые ключи вида 0, 1, 2 и т.д. Соответственно дальнейший вызов curl_exec портится.  А вот при раздельном задании всё работает как надо.